### PR TITLE
Update DispatchFollowUpADayBefore.html

### DIFF
--- a/DispatchFollowUpADayBefore.html
+++ b/DispatchFollowUpADayBefore.html
@@ -656,10 +656,7 @@
                             <span class="detail-label">📅 Dispatch Date:</span>
                             <span class="detail-value">${formatDateForDisplay(parseDate(order.dispatchDate))}</span>
                         </div>
-                        <div class="detail-row">
-                            <span class="detail-label">⏰ Confirmed On:</span>
-                            <span class="detail-value">${formatDateTimeForDisplay(parseDate(order.dispatchDateTimeStamp))}</span>
-                        </div>
+                        
                         ${order.crmRemark ? `
                         <div class="detail-row">
                             <span class="detail-label">💬 CRM Remark:</span>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Removed the "Confirmed On" field from the Dispatch Follow-Up view shown a day before dispatch.
  - Streamlined the order details panel while keeping all other fields (CRM Remark, Purchase Remark, Follow Up Deadline, Category, Delayed Reason, and document/action sections) unchanged.
  - No impact on data fetching or processing; purely a UI adjustment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->